### PR TITLE
Use all available place for the root partition.

### DIFF
--- a/control/installation.xml
+++ b/control/installation.xml
@@ -40,7 +40,8 @@
                     <fs_type>btrfs</fs_type>
                     <desired_size config:type="disksize">60 GiB</desired_size>
                     <min_size config:type="disksize">40 GiB</min_size>
-                    <max_size config:type="disksize">80 GiB</max_size>
+                    <max_size config:type="disksize">unlimited</max_size>
+                    <weight config:type="disksize">1</weight>
                     <!-- Always use snapshots, no matter what -->
                     <snapshots config:type="boolean">true</snapshots>
                     <snapshots_configurable config:type="boolean">false</snapshots_configurable>

--- a/control/installation.xml
+++ b/control/installation.xml
@@ -41,7 +41,7 @@
                     <desired_size config:type="disksize">60 GiB</desired_size>
                     <min_size config:type="disksize">40 GiB</min_size>
                     <max_size config:type="disksize">unlimited</max_size>
-                    <weight config:type="disksize">1</weight>
+                    <weight config:type="integer">1</weight>
                     <!-- Always use snapshots, no matter what -->
                     <snapshots config:type="boolean">true</snapshots>
                     <snapshots_configurable config:type="boolean">false</snapshots_configurable>

--- a/package/system-role-sap-business-one.changes
+++ b/package/system-role-sap-business-one.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Tue Aug 22 13:54:57 UTC 2023 - Peter Varkoly <varkoly@suse.com>
+
+- SAP Business One installer does a strange partitioning
+  (bsc#1212652) 
+- 15.4.1
+
+-------------------------------------------------------------------
 Thu Mar 23 14:20:56 UTC 2023 - Peter Varkoly <varkoly@suse.com>
 
 - Initial version. Impl: Automatic Setup for SAP BusinessOne

--- a/package/system-role-sap-business-one.spec
+++ b/package/system-role-sap-business-one.spec
@@ -36,7 +36,7 @@ BuildRequires:  yast2-installation-control >= 4.0.0
 
 Url:            https://github.com/yast/system-role-sap-business-one
 AutoReqProv:    off
-Version:        15.4.0
+Version:        15.4.1
 Release:        0
 Summary:        Server SAP Business One role definition
 License:        MIT


### PR DESCRIPTION
Fixing bsc#1212652 SAP Business One installer does a strange partitioning


## Problem

The partition proposal does not use all aviable places for the root volume

- *https://bugzilla.suse.com/show_bug.cgi?id=1212652*

## Solution

*Set max_size to unlimited*
*Add weight with value 1*